### PR TITLE
_nodes/stats?all is broken in new versions of ElasticSearch

### DIFF
--- a/newrelic_python_agent/plugins/elasticsearch.py
+++ b/newrelic_python_agent/plugins/elasticsearch.py
@@ -18,7 +18,7 @@ class ElasticSearch(base.JSONStatsPlugin):
     GAUGE_MATCH = ['Current']
 
     DEFAULT_HOST = 'localhost'
-    DEFAULT_PATH = '/_nodes/stats?all'
+    DEFAULT_PATH = '/_nodes/stats'
     DEFAULT_PORT = 9200
     GUID = 'com.meetme.newrelic_elasticsearch_node_agent'
 


### PR DESCRIPTION
Refer to issue discussed here https://github.com/elastic/elasticsearch/issues/21410. As an alternative it was suggested to use "/_nodes/stats" or "/_nodes/stats/_all" or "/_nodes/stats?metric=_all". For backward compatibility till 0.90 using no flags should work as the "/_nodes/stats" returns all stats by default and is consistent across all versions so far.

This fixes #17 