### PR TITLE
use thread.start() to start an actual thread

### DIFF
--- a/newrelic_python_agent/agent.py
+++ b/newrelic_python_agent/agent.py
@@ -120,7 +120,7 @@ class NewRelicPythonAgent(helper.Controller):
                                               'plugin': plugin,
                                               'poll_interval':
                                                   int(self._wake_interval)})
-            thread.run()
+            thread.start()
             self.threads.append(thread)
 
     def process(self):


### PR DESCRIPTION
thread.run() just runs the code, doesn't spawn off a new thread first.