### PR TITLE
issue #22 - support dynamic configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,8 @@ ehthumbs_vista.db
 Desktop.ini
 
 # VIM tempfiles
+*~
+*.swo
 *.swp
 
 # Recycle Bin used on file shares

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ ehthumbs_vista.db
 # Folder config file
 Desktop.ini
 
+# VIM tempfiles
+*.swp
+
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,7 @@ You can also use an optional description with the plugin name to define
 multiple descrete blocks that use the same plugin:
 
 ::
+
     plugin_name:local:
       - name: local_target
         host: localhost
@@ -156,6 +157,7 @@ returning metric data, it returns config blocks to apply to the running
 config.  The result is a dictionary that looks like:
 
 ::
+
     timestamp: unix timestamp
     application:
         plugin_name:desc1:
@@ -180,6 +182,7 @@ since the last successful run.  Specify the number of seconds to wait
 between runs.  An example config that sets a 5 minute refresh interval:
 
 ::
+
     exampleConfigPlugin:
         name: somename
         refresh_interval: 300

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,59 @@ You can also use a single mapping like follows:
 
 The fields for plugin configurations can vary due to a plugin's configuration requirements. The name value in each stanza is only required when using multiple targets in a plugin. If it is only a single target, the name will be taken from the server's hostname.
 
+You can also use an optional description with the plugin name to define
+multiple descrete blocks that use the same plugin:
+
+::
+    plugin_name:local:
+      - name: local_target
+        host: localhost
+        foo: bar
+    plugin_name:remote:
+      - name: remote_target
+        host: remotehost
+        foo: bar
+
+This can be very useful when using dynamic config blocks.  You could
+specify a block that's statically defined and a separate set that's
+dynamically changed, even though both might use the same plugin type.
+
+Dynamic Plugins
+---------------
+If a plugin is a subclass of the ``base.ConfigPlugin`` class, then it is
+considered a config plugin, rather than a metric plugin.  Instead of
+returning metric data, it returns config blocks to apply to the running
+config.  The result is a dictionary that looks like:
+
+::
+    timestamp: unix timestamp
+    application:
+        plugin_name:desc1:
+            - name: config1
+              foo: bar
+            - name: config2
+              foo: bar
+        plugin_name:desc2:
+
+This will replace the config blocks as specified by ``plugin_name:desc1``
+and ``plugin_name:desc2`` in the running config.  If the new config for a
+block is empty (like ``plugin_name:desc2`` in this example), then the
+config block will be removed from the running config.  The entire config
+block is replaced by these results.
+
+This entire result is saved and presented to the plugin the next time it
+runs so it can know what the previous results were.  A base ``ConfigPlugin``
+plugin does not require any parameters to run, but can optionally take a
+``refresh_interval`` setting to determine how often it should run.  It
+uses the ``timestamp`` of the previous results to know how long it's been
+since the last successful run.  Specify the number of seconds to wait
+between runs.  An example config that sets a 5 minute refresh interval:
+
+::
+    exampleConfigPlugin:
+        name: somename
+        refresh_interval: 300
+
 APC Installation Notes
 ----------------------
 Copy the ``apc-nrp.php`` script to a directory that can be served by your web server or ``php-fpm`` application. Edit the ``newrelic-python-agent`` configuration to point to the appropriate URL.
@@ -290,7 +343,12 @@ Configuration Example
     Application:
       license_key: REPLACE_WITH_REAL_KEY
       poll_interval: 60
+
+      # optional settings (and their defaults) when talking to newrelic:
       #newrelic_api_timeout: 10
+      #verify_ssl_cert: true
+      #skip_newrelic_upload: true
+      #endpoint: https://platform-api.newrelic.com/platform/v1/metrics
       #proxy: http://localhost:8080
 
       apache_httpd:
@@ -446,7 +504,7 @@ Configuration Example
           maxBytes: 10485760
           backupCount: 3
       loggers:
-        newrelic-python-agent:
+        newrelic_python_agent:
           level: INFO
           propagate: True
           handlers: [console, file]

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ You can also use a single mapping like follows:
 The fields for plugin configurations can vary due to a plugin's configuration requirements. The name value in each stanza is only required when using multiple targets in a plugin. If it is only a single target, the name will be taken from the server's hostname.
 
 You can also use an optional description with the plugin name to define
-multiple descrete blocks that use the same plugin:
+multiple discrete blocks that use the same plugin:
 
 ::
 

--- a/newrelic_python_agent/agent.py
+++ b/newrelic_python_agent/agent.py
@@ -168,7 +168,7 @@ class NewRelicPythonAgent(helper.Controller):
                                                       int(self._wake_interval)})
             LOGGER.info("Starting plugin instance %s as thread %s", instance_name, thread.getName())
             self.thread_names[instance_name] = thread.getName()
-            thread.run()
+            thread.start()
             self.threads.append(thread)
 
     def clean_last_values(self):

--- a/newrelic_python_agent/agent.py
+++ b/newrelic_python_agent/agent.py
@@ -17,6 +17,7 @@ import gzip
 
 from newrelic_python_agent import __version__
 from newrelic_python_agent import plugins
+import newrelic_python_agent.plugins.base as base
 
 is_py2 = sys.version[0] == '2'
 if is_py2:
@@ -38,7 +39,7 @@ class NewRelicPythonAgent(helper.Controller):
     """
 
     IGNORE_KEYS = ['license_key', 'proxy', 'endpoint', 'verify_ssl_cert',
-                   'poll_interval', 'wake_interval', 'newrelic_api_timeout']
+                   'poll_interval', 'wake_interval', 'newrelic_api_timeout', 'skip_newrelic_upload']
 
     MAX_METRICS_PER_REQUEST = 10000
     PLATFORM_URL = 'https://platform-api.newrelic.com/platform/v1/metrics'
@@ -53,6 +54,8 @@ class NewRelicPythonAgent(helper.Controller):
         """
         super(NewRelicPythonAgent, self).__init__(args, operating_system)
         self.derive_last_interval = dict()
+        self.config_last_result = dict()
+        self.clean_values = False
         self.endpoint = self.PLATFORM_URL
         self.http_headers = {'Accept': 'application/json',
                              'Content-Encoding': 'gzip',
@@ -63,6 +66,7 @@ class NewRelicPythonAgent(helper.Controller):
                                self.config.application.get('poll_interval') or
                                self.WAKE_INTERVAL)
         self.next_wake_interval = int(self._wake_interval)
+        self.config_queue = queue.Queue()
         self.publish_queue = queue.Queue()
         self.threads = list()
         info = tuple([__version__] + list(self.system_platform))
@@ -104,26 +108,80 @@ class NewRelicPythonAgent(helper.Controller):
             licensekey = self.config.application.license_key
         return licensekey
 
-    def poll_plugin(self, plugin_name, plugin, config):
+    def get_instance_name(self, plugin_name, instance):
+        """
+        Determine a unique instance name for a plugin.  This is done by combining the
+        plugin block name + the name field + an instance number
+
+        Example:
+            plugin name = mysql[:desc]
+            block name = name field in block or unnamed
+            instance number = incremental number in case previous is not unique
+
+        :param str plugin_name: The plugin block name as defined in the application config
+        :param dict instance: The instance config block
+        :rtype: str
+        """
+        # start with the base name of the plugin + name field
+        name = "%s:%s" % (plugin_name, instance.get('name', 'unnamed'))
+        i = 0
+        instance_name = "%s:%i" % (name, i)
+        while instance_name in self.thread_names:
+            i = i + 1
+            instance_name = "%s:%i" % (name, i)
+
+        return instance_name
+
+    def start_plugin(self, plugin_name, plugin, config):
         """Kick off a background thread to run the processing task.
 
-        :param newrelic_python_agent.plugins.base.Plugin plugin: The plugin
-        :param dict config: The config for the plugin
+        :param plugin: The plugin name as defined in the application config
+        :param config: The set of instance configs for the plugin
+        :type plugin: newrelic_python_agent.plugins.base.Plugin
+        :type config: dict or list(dict)
 
         """
 
         if not isinstance(config, (list, tuple)):
             config = [config]
 
+        LOGGER.debug("Plugin config: %s", config)
+
+        # the instance names must be unique so we can store the results for each.
+        # use the 'name' field, if specified.  If there are duplicate names, we
+        # simply append a number so it is unique.  As long as the the order in the
+        # config remains the same, then the instance number will remain the same.
         for instance in config:
-            thread = threading.Thread(target=self.thread_process,
-                                      kwargs={'config': instance,
-                                              'name': plugin_name,
-                                              'plugin': plugin,
-                                              'poll_interval':
-                                                  int(self._wake_interval)})
-            thread.start()
+            instance_name = self.get_instance_name(plugin_name, instance)
+
+            if issubclass(plugin, base.ConfigPlugin):
+                thread = threading.Thread(target=self.thread_config_process,
+                                          kwargs={'config': instance,
+                                                  'name': instance_name,
+                                                  'plugin': plugin})
+            else:
+                thread = threading.Thread(target=self.thread_metric_process,
+                                          kwargs={'config': instance,
+                                                  'name': instance_name,
+                                                  'plugin': plugin,
+                                                  'poll_interval':
+                                                      int(self._wake_interval)})
+            LOGGER.info("Starting plugin instance %s as thread %s", instance_name, thread.getName())
+            self.thread_names[instance_name] = thread.getName()
+            thread.run()
             self.threads.append(thread)
+
+    def clean_last_values(self):
+        """Remove any saved value data for plugins that are no longer configured"""
+        for key in self.derive_last_interval.keys():
+            if key not in self.thread_names:
+                LOGGER.info("Removing last interval data for unused %s", key)
+                self.derive_last_interval.pop(key)
+        for key in self.config_last_result.keys():
+            if key not in self.thread_names:
+                LOGGER.info("Removing last config result for unused %s", key)
+                self.config_last_result.pop(key)
+        self.clean_values = False
 
     def process(self):
         """This method is called after every sleep interval. If the intention
@@ -132,21 +190,31 @@ class NewRelicPythonAgent(helper.Controller):
 
         """
         start_time = time.time()
-        self.start_plugin_polling()
+        self.start_plugins()
 
         # Sleep for a second while threads are running
         while self.threads_running:
             time.sleep(1)
 
+        # threads are done, so empty the list
         self.threads = list()
+
+        # send any collected metrics to newrelic
         self.send_data_to_newrelic()
+
+        # perform any config updates
+        self.process_config_plugins()
+
+        if self.clean_values:
+            self.clean_last_values()
+
         duration = time.time() - start_time
         self.next_wake_interval = self._wake_interval - duration
         if self.next_wake_interval < 1:
             LOGGER.warning('Poll interval took greater than %i seconds',
                            duration)
             self.next_wake_interval = int(self._wake_interval)
-        LOGGER.info('Stats processed in %.2f seconds, next wake in %i seconds',
+        LOGGER.info('Threads processed in %.2f seconds, next wake in %i seconds',
                     duration, self.next_wake_interval)
 
     def process_min_max_values(self, component):
@@ -199,7 +267,41 @@ class NewRelicPythonAgent(helper.Controller):
             }
         return None
 
+    def configuration_reloaded(self):
+        # if the configuration was reloaded, then flag it so we can
+        # check if we need to purget any old data.
+        self.clean_values = True
+
+    def process_config_plugins(self):
+        """Process the queue of config plugin results"""
+
+        while self.config_queue.qsize():
+            (name, data) = self.config_queue.get()
+            if isinstance(data, dict) and data.get('application'):
+                # this is a success, so store save this
+                self.config_last_result[name] = data
+                for plugin_name in data['application'].keys():
+                    action = "empty"
+                    if data['application'][plugin_name]:
+                        # config is not empty
+                        if plugin_name in self.config.application \
+                                and self.config.application[plugin_name] == data['application'][plugin_name]:
+                            action = "unchanged"
+                        else:
+                            self.config.application.update({plugin_name: data['application'][plugin_name]})
+                            action = "updated"
+                            self.clean_values = True
+                    elif plugin_name in self.config.application:
+                        # config is empty for an existing plugin_name, so remove it
+                        self.config.application.pop(plugin_name)
+                        action = "removed"
+                        self.clean_values = True
+
+                    if action:
+                        LOGGER.info("Plugin instance %s result: %s %s", name, plugin_name, action)
+
     def send_data_to_newrelic(self):
+        """Process the queue of metric plugin results"""
         metrics = 0
         components = list()
         while self.publish_queue.qsize():
@@ -234,6 +336,10 @@ class NewRelicPythonAgent(helper.Controller):
         """
         if not metrics:
             LOGGER.warning('No metrics to send to NewRelic this interval')
+            return
+
+        if self.config.application.get('skip_newrelic_upload'):
+            LOGGER.info('Not sending %i metrics to NewRelic', metrics)
             return
 
         LOGGER.info('Sending %i metrics to NewRelic', metrics)
@@ -286,28 +392,40 @@ class NewRelicPythonAgent(helper.Controller):
             LOGGER.exception('Attempting to import %s', plugin_path)
             return None
 
-    def start_plugin_polling(self):
-        """Iterate through each plugin and start the polling process."""
+    def start_plugins(self):
+        """Iterate through each plugin and start the thread(s)."""
+
+        # reset the configured instance names
+        self.thread_names = dict()
+
         for plugin in [key for key in self.config.application.keys()
                        if key not in self.IGNORE_KEYS]:
-            LOGGER.info('Enabling plugin: %s', plugin)
+
+            # ignore this if the config is empty
+            if not self.config.application.get(plugin):
+                continue
+
+            LOGGER.info('Checking plugin config: %s', plugin)
+            # support plugin:id format to allow multiple config blocks
+            # for a single plugin
+            plugin_name = plugin.split(":", 1)[0]
             plugin_class = None
 
             # If plugin is part of the core agent plugin list
-            if plugin in plugins.available:
-                plugin_class = self._get_plugin(plugins.available[plugin])
+            if plugin_name in plugins.available:
+                plugin_class = self._get_plugin(plugins.available[plugin_name])
 
             # If plugin is in config and a qualified class name
-            elif '.' in plugin:
-                plugin_class = self._get_plugin(plugin)
+            elif '.' in plugin_name:
+                plugin_class = self._get_plugin(plugin_name)
 
             # If plugin class could not be imported
             if not plugin_class:
-                LOGGER.error('Enabled plugin %s not available', plugin)
+                LOGGER.error('Plugin %s not available', plugin_name)
                 continue
 
-            self.poll_plugin(plugin, plugin_class,
-                             self.config.application.get(plugin))
+            self.start_plugin(plugin, plugin_class,
+                              self.config.application.get(plugin))
 
     @property
     def threads_running(self):
@@ -321,22 +439,36 @@ class NewRelicPythonAgent(helper.Controller):
                 return True
         return False
 
-    def thread_process(self, name, plugin, config, poll_interval):
+    def thread_config_process(self, name, plugin, config):
+        """
+        Create a thread process to return a dynamic config for a plugin.
+        The result of this plugin is added to a Queue object which is used
+        to maintain the stack of running config plugins.
+
+        :param str name: The unique instance name of the plugin
+        :param newrelic_python_agent.plugins.base.ConfigPlugin plugin: The plugin class
+        :param dict config: The plugin configuration
+        """
+        previous_state = self.config_last_result.get(name)
+        obj = plugin(config, previous_state)
+        obj.start()
+        self.config_queue.put((name, obj.results()))
+
+    def thread_metric_process(self, name, plugin, config, poll_interval):
         """Created a thread process for the given name, plugin class,
         config and poll interval. Process is added to a Queue object which
-        used to maintain the stack of running plugins.
+        used to maintain the stack of running metrics plugins.
 
-        :param str name: The name of the plugin
-        :param newrelic_python_agent.plugin.Plugin plugin: The plugin class
+        :param str name: The unique instance name of the plugin
+        :param newrelic_python_agent.plugins.base.Plugin plugin: The plugin class
         :param dict config: The plugin configuration
         :param int poll_interval: How often the plugin is invoked
 
         """
-        instance_name = "%s:%s" % (name, config.get('name', 'unnamed'))
         obj = plugin(config, poll_interval,
-                     self.derive_last_interval.get(instance_name))
+                     self.derive_last_interval.get(name))
         obj.poll()
-        self.publish_queue.put((instance_name, obj.values(),
+        self.publish_queue.put((name, obj.values(),
                                 obj.derive_last_interval))
 
     @property

--- a/newrelic_python_agent/agent.py
+++ b/newrelic_python_agent/agent.py
@@ -278,16 +278,21 @@ class NewRelicPythonAgent(helper.Controller):
         while self.config_queue.qsize():
             (name, data) = self.config_queue.get()
             if isinstance(data, dict) and data.get('application'):
-                # this is a success, so store save this
+                LOGGER.debug("%s results" % name, extra={"results": data.get('application')})
+
+                # this is a success, so save this
                 self.config_last_result[name] = data
+
+                # process each result individually
                 for plugin_name in data['application'].keys():
-                    action = "empty"
+                    action = None
                     if data['application'][plugin_name]:
                         # config is not empty
                         if plugin_name in self.config.application \
                                 and self.config.application[plugin_name] == data['application'][plugin_name]:
                             action = "unchanged"
                         else:
+                            # update or add new block
                             self.config.application.update({plugin_name: data['application'][plugin_name]})
                             action = "updated"
                             self.clean_values = True
@@ -298,7 +303,7 @@ class NewRelicPythonAgent(helper.Controller):
                         self.clean_values = True
 
                     if action:
-                        LOGGER.info("Plugin instance %s result: %s %s", name, plugin_name, action)
+                        LOGGER.info("Plugin instance %s result %s %s", name, plugin_name, action)
 
     def send_data_to_newrelic(self):
         """Process the queue of metric plugin results"""

--- a/newrelic_python_agent/plugins/__init__.py
+++ b/newrelic_python_agent/plugins/__init__.py
@@ -13,6 +13,7 @@ available = {
     'memcached': 'newrelic_python_agent.plugins.memcached.Memcached',
     'mongodb': 'newrelic_python_agent.plugins.mongodb.MongoDB',
     'mysql': 'newrelic_python_agent.plugins.mysql.MySQL',
+    'mysql-config': 'newrelic_python_agent.plugins.mysql-config.MySQLConfig',
     'nginx': 'newrelic_python_agent.plugins.nginx.Nginx',
     'pgbouncer': 'newrelic_python_agent.plugins.pgbouncer.PgBouncer',
     'php_apc': 'newrelic_python_agent.plugins.php_apc.APC',

--- a/newrelic_python_agent/plugins/mysql-config.py
+++ b/newrelic_python_agent/plugins/mysql-config.py
@@ -1,0 +1,743 @@
+"""
+MySQLConfig Plugin
+
+This is used to dynamically configure a MySQL plugin.  It's main purpose is to query
+AWS to find all RDS instances in a particular region.  You can select which instances
+to monitor by including and excluding based on the instance name or by tags.
+
+All boto3 exceptions are fatal and will cause the config script to exit.  Therefore, if an credstash or cloudformation
+should not be queried, make sure those settings are not set so it knows not to even try.
+
+Some settings can be overridden by environment variables:
+
+    RDS_REGIONS
+        if defined, this will override any `regions` defined in the config.  Can be separated by
+        comma, colon, semi-colon, or whitespace. (e.g. "us-west-1, us-west-2;us-east-1 : us-east-2")
+
+    CLOUDFORMATION_HOSTED_ZONE_EXPORT_NAME
+        overrides `cloudformation_hosted_zone_export_name` in all region-specific settings
+
+The following settings are supported:
+
+    `name`: A descriptive name of this config block
+    `refresh_interval`: How often this module should run (seconds)
+        type: integer
+        default: 0 (run every time)
+    `regions`: The list of regions to query for RDS instances
+        type: comma, space, colon, semi-colon separated string or list of region names
+        env: `RDS_REGIONS` environment variable takes precedence over any config entries
+        default: the current region if on an EC2 instance, or the current boto3 session region
+    `settings`:
+        A dictionary containing region-specific settings, keyed by region name or `default`.
+        If a setting is defined in a region-specific sub-section, it's used, otherwise the
+        setting from the `default` section is used.
+
+        The following region-specific settings are supported:
+
+            Used only by `targets` entries to create fully qualified domain names, if required:
+
+                `domain`: The domain name for this region.
+                `cloudformation_hosted_zone_export_name`: A cloudformation export name
+                    If `domain` is not specified, then query cloudformation exports for an export by this name
+                    and use that as the domain name.
+
+            To populate the MySQL config parameters for each instance in a region:
+
+                `user`: The username to use in the `user` field of the MySQL config.
+                `password`: The password to use in the `password` field of the MySQL config.
+
+            If either `user` or `password` is missing, and `credstash_table` is defined for the region, then we will
+            attempt to look up the values from credstash using the following settings (note that each region queries
+            credstash in that specific region):
+
+                `credstash_table`: The table in credstash to query.
+                `credstash_user_key`: The key in the credstash table to get the `user` value.
+                `credstash_password_key`: The key in the credstash table to get the `password` value.
+
+            The following settings allow you to filter which RDS instances to monitor:
+
+                `include`: Only include RDS instances who match this set of tests
+                `exclude`: Exclude any RDS intance that matches this set of tests
+
+                Note: see `is_match()` for details on the supported format.
+
+        Any other setting defined in a specific region or in the `default` section will be assumed to
+        be a config parameter to pass along.  For instance, `metrics` can be specified to list which metrics
+        to collect.  Or, `connect_timeout` can be used to override the default `connect_timeout` in the MySQL
+        plugin.  These settings will be applied to each instance config related to the region, including the
+        ones in `targets`.
+
+    `targets`:
+        A way to define custom targets that are not otherwise found by querying RDS.  This can be useful to reference an
+        RDS by it's public name instead of instance name so as it moves or new instances are created, the historical
+        data remains consistent.
+
+        This is a list of targets, which can be in the form:
+
+            - a string, which is treated as the `name`
+            - a dictionary with the following attributes:
+                `name`: The `name` in the generated mysql config with be this with ` (manual)` appended.
+                    e.g. `db1` as a name will result in a config name of `db1 (manual)`
+                `host`: The hostname to connect to.  If not defined, then use `name`.  If `name` is not a
+                        fully-qualified domain name, then determined the domain from the `region` specified.
+                `region`: The region the domain name and/or credstash values should come from.  If not
+                          specified and we need these details, the first region in `regions` will be used.
+                `user`: The username to connect to the db.
+                `password`: The password to connect to the db.
+                    Note: if either `user` or `password` are not specified, then the settings for the `region`
+                    will be used.  This might include pulling the credstash values for that region.
+
+                Note: Any other entries will be included in the generated config without modification.
+                      (e.g. `metrics`, `connect_timeout`, `database`, etc.)  Settings defined here will be
+                      applied after any region-specific raw config settings, so these will take precedence.
+
+        Examples:
+
+        ```
+        regions:
+          - us-east-1
+          - us-west-2
+        targets:
+          - db1
+        ```
+
+        will produce a config of:
+
+        ```
+        - name: db1 (manual)
+          host: db1.domain.com
+          user: <username defined by first region (us-east-1)>
+          password: <password defined by first region (us-east-1)>
+        ```
+
+        ```
+        targets:
+          - name: db1
+            host: db1.my.domain.com
+            region: us-west-1
+            user: myuser
+        ```
+
+        will produce a config of:
+
+        ```
+        - name: db1 (manual)
+          host: db1.my.domain.com
+          user: myuser
+          password: <password defined by `us-west-1`>
+        ```
+
+
+Example:
+
+MySQLConfig:
+  - name: RDS
+    refresh_interval: 300
+    target_plugin_name: mysql:RDS
+    regions:
+      - us-west-1
+      - us-west-2
+    settings:
+        default:
+            cloudformation_hosted_zone_export_name: Default-HostedZoneName
+            credstash_table: newrelic_monitor
+            credstash_user_key: newrelic_monitor_username
+            credstash_password_key: newrelic_monitor_password
+            exclude: test
+            include:
+              - tag: newrelic-monitor
+                values: "yes"
+        us-west-2:
+            domain: mycompany.com
+            user: monitor
+            password: monitorpass
+            include:
+              - prod
+              - tag: newrelic-monitor
+                values:
+                  - "yes"
+                  - "true"
+
+
+"""
+
+import logging
+import re
+import os
+import urllib2
+import json
+import credstash
+import boto3
+from botocore.exceptions import ClientError
+
+from newrelic_python_agent.plugins import base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MySQLConfig(base.ConfigPlugin):
+
+    # region settings that we handle.  Any other keys will be passed through directly.
+    SETTINGS_KEYS = ['user', 'password', 'include', 'exclude', 'host', 'name', 'domain',
+                     'cloudformation_hosted_zone_export_name', 'region', 'credstash_table',
+                     'credstash_user_key', 'credstash_password_key']
+
+    def initialize(self):
+        """Initialize ourselves, preparing the required variables."""
+
+        self.rds_cache = dict()
+        self.creds_cache = dict()
+        self.exports_cache = dict()
+        self.tags_cache = dict()
+
+        # This overrides any config values, if defined.
+        r = self.get_region_from_environment()
+        if r:
+            self.config['regions'] = r
+
+        # we expect/want these to be lists, but support
+        # a single string (with comma separated items) for convenience
+        # or just a single dict (for targets)
+        for prop in ['regions', 'targets']:
+            if prop in self.config:
+                if isinstance(self.config[prop], str):
+                    self.config[prop] = self.string_to_list(self.config[prop])
+                elif isinstance(self.config[prop], dict):
+                    self.config[prop] = [self.config[prop]]
+
+        # default to only the current region if none are specified.
+        if 'regions' not in self.config:
+            self.config['regions'] = self.get_default_region()
+
+    def get_default_region(self):
+        """
+        Auto-determine the local region, by either the EC2 metadata or the default session.
+
+        :return: The AWS region name
+        :rtype: str
+        """
+        return self.get_region_from_metadata() or self.get_region_from_session()
+
+    def get_region_from_environment(self):
+        """
+        If `RDS_REGIONS` is defined in the environment, then use that as a list of regions to query.
+
+            us-west1:us-west2
+
+        :return: list of regions
+        """
+        r = os.getenv('RDS_REGIONS')
+        if r:
+            return self.string_to_list(r)
+
+    def get_region_from_metadata(self):
+        """
+        Query the EC2 metadata for the local region.
+
+        :return: The AWS region the EC2 instance is running.
+        :rtype: str or None
+        """
+        LOGGER.info('Obtaining region from EC2 metadata.')
+        try:
+            url = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
+            document = json.loads(urllib2.urlopen(url, timeout=3).read())
+            return [document['region']]
+        except urllib2.URLError as e:
+            LOGGER.warning("failed to query EC2 metadata: %s", e)
+            pass
+
+    def get_region_from_session(self):
+        """
+        Query the region as defined by the default session.  Useful for testing and running by hand outside of EC2.
+
+        :return: The AWS region of the default session.
+        :rtype: str
+        """
+        LOGGER.info('Obtaining region from default session.')
+        return [boto3.session.Session().region_name]
+
+    def string_to_list(self, string):
+        """
+        Split a string on any combination of: comma, space, semi-colon, colon
+
+        :param str string: The string to split
+        :return: a list of strings
+        """
+        return re.split("\s*[;:, ]+\s*", string)
+
+    def build_config(self):
+        """
+        Build a full config object for the plugin defined by the `target_plugin_name` config variable.
+        This prepares the `state` which will be used as the return value.
+
+        This is the entry point of a ConfigPlugin object.
+
+        :return: None
+        """
+
+        plugin = self.config.get('target_plugin_name')
+        if not plugin:
+            LOGGER.error("must specify 'target_plugin_name' config value")
+            return
+
+        LOGGER.info("building config for '%s'", plugin)
+        self.initialize()
+
+        try:
+            instances = self.get_all_rds_instances()
+            instances.extend(self.get_manual_instances())
+            LOGGER.info("found %s database instances to monitor", len(instances))
+            self.add_config_block(plugin, instances)
+        except ClientError as e:
+            # all boto3 exceptions are simply logged here, but are fatal
+            LOGGER.error(e)
+        finally:
+            LOGGER.info("Exiting with %d application results", len(self.state['application']))
+
+    def cache_cloudformation_exports(self, region):
+        """
+        Query cloudformation exports for a region and cache them for subsequent queries
+
+        :param str region: The name of the AWS region this applies to.
+        :return: None
+        """
+
+        LOGGER.info("querying cloudformation exports for %s", region)
+        c = boto3.client('cloudformation', region_name=region)
+        more = True
+        args = dict()
+        self.exports_cache[region] = dict()
+        while more:
+            result = c.list_exports(**args)
+            for e in result['Exports']:
+                self.exports_cache[region][e['Name']] = e['Value']
+            if 'NextToken' in result and result['NextToken'] is not None:
+                args['NextToken'] = result['NextToken']
+                more = True
+            else:
+                more = False
+
+    def get_hosted_zonename(self, region):
+        """
+        Determine the hosted zone name from a cloudformation export name for a particular region
+
+        :param str region: The name of the region to query.
+        :return: The domain name of the region.
+        :rtype: str
+        """
+        export_name = os.getenv('CLOUDFORMATION_HOSTED_ZONE_EXPORT_NAME',
+                                self.get_region_setting(region, "cloudformation_hosted_zone_export_name"))
+        if not region:
+            region = self.config['regions'][0]
+        if region not in self.exports_cache:
+            self.cache_cloudformation_exports(region)
+        return self.exports_cache[region].get(export_name)
+
+    def get_fqdn(self, name, region):
+        """
+        Convert `name` to a fully-qualified domain name, as determined by the region specified.
+
+        :param str name: The name to convert to a fully-qualified name.
+        :param str region: The name of the AWS region this applies to.
+        :return: The fully-qualified domain name.
+        :rtype: str
+        """
+        if '.' in name:
+            # assumed to already be an fqdn
+            return name
+
+        domain = self.get_region_setting(region, "domain") or self.get_hosted_zonename(region)
+        if domain:
+            return "%s.%s" % (name, domain)
+        return name
+
+    def get_credentials(self, region):
+        """
+        Determine the credentials to use to connect to an RDS instance in an AWS region.
+        If credstash is configured for the region, then query that for the info.  Otherwise, use
+        the user and password config fields.  The result is cached so we only have to query
+        credstash once per instance run.
+
+        :param str region: The name of the AWS region
+        :return: user and password
+        :rtype: list
+        """
+        # cache the credentials so we only query once
+        if region not in self.creds_cache:
+            LOGGER.info("querying credentials for region %s", region)
+            # these will throw an exception if credstash is configured but cannot be queried,
+            # otherwise, they will simply return None
+            u = self.get_credstash_username(region)
+            p = self.get_credstash_password(region)
+
+            # if either of these are not found, try to pull them from the settings
+            if not u:
+                u = self.get_region_setting(region, "user")
+            if not p:
+                p = self.get_region_setting(region, "password")
+
+            # cache the response for this region
+            self.creds_cache[region] = [u, p]
+
+        return self.creds_cache[region]
+
+    def get_credstash_username(self, region):
+        """
+        Query credstash for the username to use to connect to the RDS instance.
+
+        :param str region: The name of the AWS region to query credstash.
+        :return: The username as specified in credstash
+        :rtype: str
+        """
+        key = self.get_region_setting(region, "credstash_user_key")
+        if key:
+            return self.query_credstash(key, region)
+
+    def get_credstash_password(self, region):
+        """
+        Query credstash for the password to use to connect to the RDS instance.
+
+        :param str region: The name of the AWS region to query credstash.
+        :return: The password as specified in credstash
+        :rtype: str
+        """
+        key = self.get_region_setting(region, "credstash_password_key")
+        if key:
+            return self.query_credstash(key, region)
+
+    def query_credstash(self, key, region):
+        """
+        Query credstash for a specific key in the credstash table as specified by
+        the `credstash_table` config setting.  Returns None if no table is configured.
+
+        :param str key: The key in the credstash table to query.
+        :param str region: The name of the AWS region to query credstash.
+        :return: The value of the credstash key.
+        :rtype: str or None
+        """
+        table = self.get_region_setting(region, "credstash_table")
+        if table:
+            r = credstash.getSecret(key,
+                                    region=region,
+                                    table=table)
+            return r
+        return None
+
+    def get_region_setting(self, region, name):
+        """
+        Convenience function to pull a config value from a region-specific section first, otherwise
+        from the default section.
+
+        :param str region: the name of the region
+        :param str name: the name of the setting to look for
+        """
+        return self.get_config_value(["settings.%s.%s" % (region, name), "settings.default.%s" % name])
+
+    def get_config_value(self, name, default=None):
+        """
+        Convenience function to pull a dot-separated name from the config
+        without having to worry about if each level in the heirarchy exists.
+
+        :param str name: a dot-separated config variable
+        :param list name: a list of dot-separated config variables to search for.  return first match
+        :param str default: the default result to return if no matches are found.
+        """
+
+        # support a list of config values to search for, returning the first match
+        if isinstance(name, list):
+            for n in name:
+                r = self.get_config_value(n)
+                if r is not None:
+                    return r
+            return default
+
+        v = self.config
+        for i in name.split('.'):
+            if i not in v:
+                return default
+            v = v[i]
+        return v
+
+    def get_all_rds_instances(self):
+        """
+        Get all RDS instances to monitor in all regions defined by the `regions` setting.
+
+        :return: A list of instance configs
+        :rtype: list
+        """
+        instances = list()
+        for region in self.config['regions']:
+            instances.extend(self.get_rds_region_instances(region))
+        return instances
+
+    def check_instance_tags(self, client, arn, test):
+        """
+        Compare the tags on an RDS instance with the name/values in our test.
+
+        :param botocore.client.RDS client: The RDS boto3 client instance to use for the query.
+        :param str arn: The ARN of the instance to query.
+        :param dict test: A tag to look for, specified as a dictionary with 'tag' as the tag name
+                          and 'values' as a list of possible values (any match will succeed).
+        :return: True if a tag key/value pair finds a match on the RDS instance, False otherwise.
+        :rtype: bool
+        """
+
+        LOGGER.debug("checking tags for '%s'", arn)
+
+        # check for an invalid test format
+        if not (isinstance(test, dict) and 'tag' in test and 'values' in test):
+            return False
+
+        # cache this arn's tags for future tests
+        if arn not in self.tags_cache:
+            self.tags_cache[arn] = client.list_tags_for_resource(ResourceName=arn)
+
+        res = self.tags_cache.get(arn)
+        # LOGGER.debug("result: %s", json.dumps(res))
+        if res and 'TagList' in res:
+            # TagList: [{'Key': key 'Value': value}]
+            for tag in res['TagList']:
+                if tag['Key'] == test['tag'] and tag['Value'] in test['values']:
+                    return True
+        return False
+
+    def get_rds_region_instances(self, region):
+        """
+        Query a region for a list of instances.  The result will be in the order as returned by
+        botocore.client.RDS, filtered as defined by the `include` and `exclude`
+        settings for the particular region.
+
+        :param str region: The name of the AWS region.
+        :return: A list of instance configs
+        :rtype: list
+        """
+        instances = []
+        more = True
+        args = {}
+
+        username, password = self.get_credentials(region)
+        if not username or not password:
+            # if either of these don't exist, we can't continue
+            LOGGER.warning("no db credentials defined for '%s' region. not probing RDS instances." % region)
+            return instances
+
+        # see if we should be doing any include/exclude regex matches
+        include = self.get_region_setting(region, 'include')
+        exclude = self.get_region_setting(region, 'exclude')
+
+        c = boto3.client('rds', region_name=region)
+        while more:
+            LOGGER.debug("querying for db instances in %s with args: %s", region, args)
+            result = c.describe_db_instances(**args)
+            for instance in result['DBInstances']:
+                if instance['Engine'] == "mysql":
+                    # include by default
+                    good = True
+                    name = instance['DBInstanceIdentifier']
+                    endpoint = instance['Endpoint']['Address']
+
+                    # if include and not (re.search(include, name) or re.search(include, endpoint)):
+                    if include and not self.is_match(c, instance, include):
+                        LOGGER.debug("excluding '%s' because it did not match include pattern of '%s'",
+                                     endpoint, self.format_pattern(include))
+                        good = False
+
+                    # if good and exclude and (re.search(exclude, name) or re.search(exclude, endpoint)):
+                    if good and exclude and self.is_match(c, instance, exclude):
+                        LOGGER.debug("excluding '%s' because it matches exclude pattern of '%s'",
+                                     endpoint, self.format_pattern(exclude))
+                        good = False
+
+                    if good:
+                        # create a stub instance
+                        i = {
+                            'name': "%s (%s)" % (name, region),
+                            'host': endpoint,
+                        }
+
+                        # include these if they are defined
+                        if username:
+                            i['user'] = username
+                        if password:
+                            i['password'] = password
+
+                        # include any passthrough settings
+                        i.update(self.get_passthrough_settings(region=region))
+
+                        # now append this to the list of instances
+                        LOGGER.debug("adding '%s' as monitored instance",
+                                     instance['Endpoint']['Address'])
+                        instances.append(i)
+                else:
+                    LOGGER.debug("skipping '%s' with unsupported '%s' engine type",
+                                 instance['Endpoint']['Address'],
+                                 instance['Engine'])
+
+            # If there are over MaxRecords (default 100), Marker will tell us
+            if 'Marker' in result:
+                # there are more results, so pull the next set
+                args['Marker'] = result['Marker']
+                more = True
+            else:
+                more = False
+        return instances
+
+    def get_passthrough_settings(self, region=None, target=None):
+        result = dict()
+
+        settings = ['settings.default']
+        if region:
+            settings.append("settings.%s" % region)
+
+        # include any extra settings defined at the region level
+        exclude = set(self.SETTINGS_KEYS)
+        for s in settings:
+            vals = self.get_config_value(s)
+            if vals:
+                for k in (set(vals) - exclude):
+                    result[k] = vals[k]
+
+        # if a target config is passed in, see if there are any settings here too
+        if target and isinstance(target, dict):
+            for k in (set(target) - exclude):
+                result[k] = target[k]
+
+        return result
+
+    def is_match(self, client, instance, tests, all=False):
+        """
+        Compare an instance with a set of tests.  The tests are a list of regex or tag comparisons
+        to check.  A set of comparisons are grouped as ORs at the top level and as ANDs at a second level.
+
+        A test can be a string, which represents a regular expression to match against the DBInstanceIdentifier
+        or Endpoint.Address properties of the instance.
+
+        A test can be a dictionary, with a key of `tag` (specifying the tag name to compare) and `values`
+        with a list of possible matching values for that tag (treated as OR).
+
+        [
+            test1
+            OR [test2 AND test3]
+            OR test4
+        ]
+
+        :param client: a boto3.client.RDS instance to query RDS
+        :param dict instance: An instance dictionary result from boto3.client.RDS.describe_rds_instances()
+        :param list tests: A list of tests to check.
+        :result: True if the tests pass, False otherwise
+        """
+        # a single entity (string or dict) is put into list form
+        if not isinstance(tests, list):
+            tests = [tests]
+
+        # The first list of tests is treated as ORs
+        for test in tests:
+            match = False
+            if isinstance(test, list) \
+                    and self.is_match(client, instance, test, all=True):
+                match = True
+            elif isinstance(test, str) \
+                    and (re.search(test, instance['DBInstanceIdentifier']) or
+                         re.search(test, instance['Endpoint']['Address'])):
+                match = True
+            elif isinstance(test, dict) \
+                    and self.check_instance_tags(client, instance['DBInstanceArn'], test):
+                match = True
+
+            # if we are matching any and there's a match, short circuit
+            if not all and match:
+                return True
+
+            # if we are matching all and there's not a match, short circuit
+            if all and not match:
+                return False
+
+        # return True if we were matching all (and didn't short-circuit earlier)
+        # return False if we were matching any (and didn't short-circuit earlier)
+        return all
+
+    def format_pattern(self, pattern):
+        """
+        Convert the include/exclude pattern to a human readable form that shows the logic more clearly.
+            - a
+            - - b
+              - c
+
+            is converted to:
+
+            a OR (b AND c)
+
+        :result: a human readable representation of the test patterns
+        """
+        if not isinstance(pattern, list):
+            pattern = [pattern]
+
+        ors = []
+        for p in pattern:
+            if isinstance(p, list):
+                ands = [str(i) for i in p]
+                p = "(%s)" % " AND ".join(ands)
+            ors.append(str(p))
+        return " OR ".join(ors)
+
+    def get_manual_instances(self):
+        """
+        Build a list of instance configs from manually-specified names.  This
+        might be useful to reference a common name rather than an instance-specific one
+        so that the metric data follows the name as instances change.
+
+        Supported formats for targets:
+
+        targets:
+          - db1                         (if just a string, then equivalent to specifying `name`)
+          - name: db2                   (uses default domain as defined by settings for first region)
+          - name: db3
+            host: db3.foo.com
+            region: us-west-2           (use credentials as defined by this region)
+          - name: db4
+            user: newrelic
+            password: somepassword
+
+        :return: A list of MySQL instance configs
+        :rtype: list
+        """
+        instances = []
+        targets = self.config.get('targets', [])
+        for target in targets:
+            if isinstance(target, str):
+                target = {'name': target}
+            if isinstance(target, dict):
+                # required setting
+                name = target['name']
+
+                # optional settings
+                user = target.get('user')
+                password = target.get('password')
+                # the region to use when determining the credentials and domain name
+                # if those are not already specified
+                region = target.get('region', self.config['regions'][0])
+
+                # use the region credentials if not specified directly
+                if not user or not password:
+                    u, p = self.get_credentials(region)
+                    if not user:
+                        user = u
+                    if not password:
+                        password = p
+
+                # now build the instance config
+                cf = {
+                    'name': "%s (manual)" % name,
+                    'host': target.get('host', self.get_fqdn(name, region)),
+                }
+                # only include these if they are defined
+                if user:
+                    cf['user'] = user
+                if password:
+                    cf['password'] = password
+
+                # now include any "extra" fields given in region or this target
+                cf.update(self.get_passthrough_settings(region=region, target=target))
+
+                instances.append(cf)
+        return instances

--- a/newrelic_python_agent/plugins/mysql-config.py
+++ b/newrelic_python_agent/plugins/mysql-config.py
@@ -20,6 +20,11 @@ Some settings can be overridden by environment variables:
 The following settings are supported:
 
     `name`: A descriptive name of this config block
+    `target_plugin_name`: The application name that the resulting config block should be assigned to.
+                          If you have a static 'mysql' block already configured, you might want the
+                          dynamic one generated here assigned as 'mysql:RDS' instead.
+        type: string
+        default: 'mysql'
     `refresh_interval`: How often this module should run (seconds)
         type: integer
         default: 0 (run every time)
@@ -275,7 +280,7 @@ class MySQLConfig(base.ConfigPlugin):
         :return: None
         """
 
-        plugin = self.config.get('target_plugin_name')
+        plugin = self.config.get('target_plugin_name', 'mysql')
         if not plugin:
             LOGGER.error("must specify 'target_plugin_name' config value")
             return


### PR DESCRIPTION
This adds support for issue #22 config plugins that can dynamically adjust the running config.  While this technically doesn't rely on any other PRs, it is most useful after PR #21 and the included mysql-config config plugin doesn't make sense without PR #23.