### PR TITLE
support derived metric as rates

### DIFF
--- a/newrelic_python_agent/plugins/mysql.py
+++ b/newrelic_python_agent/plugins/mysql.py
@@ -502,7 +502,7 @@ class MySQL(base.Plugin):
             if metric_type == "counter":
                 # Unit/Second
                 unit = "/".join((unit, "Second"))
-                self.add_derive_value(metric, unit, self.raw_metrics[metric])
+                self.add_derive_value(metric, unit, self.raw_metrics[metric], rate=True)
             else:
                 self.add_gauge_value(metric, unit, self.raw_metrics[metric])
 

--- a/newrelic_python_agent/plugins/redis.py
+++ b/newrelic_python_agent/plugins/redis.py
@@ -34,8 +34,8 @@ class Redis(base.SocketStatsPlugin):
         # but only if we have the previous values
         if ('Keys/Hit' in self.derive_last_interval.keys() and
                 'Keys/Missed' in self.derive_last_interval.keys()):
-            prev_hits = self.derive_last_interval['Keys/Hit']
-            prev_misses = self.derive_last_interval['Keys/Missed']
+            prev_hits = self.derive_last_interval['Keys/Hit'][0]
+            prev_misses = self.derive_last_interval['Keys/Missed'][0]
 
             # hits and misses since the last measure
             hits = stats.get('keyspace_hits', 0) - prev_hits


### PR DESCRIPTION
This allows us to calculate derived metrics as a rate over the interval since the last metric.  Basically, to be able to convert derived values to "/second" type metrics by diving by the duration since the metric was previously stored.