### PR TITLE
Support NEW_RELIC_LICENSE_KEY

### DIFF
--- a/newrelic_python_agent/agent.py
+++ b/newrelic_python_agent/agent.py
@@ -108,9 +108,11 @@ class NewRelicPythonAgent(helper.Controller):
         :rtype: str
 
         """
-        licensekey = os.getenv('NEWRELIC_LICENSE_KEY')
+        licensekey = os.getenv('NEW_RELIC_LICENSE_KEY')
         if licensekey is None:
-            licensekey = self.config.application.license_key
+            licensekey = os.getenv('NEWRELIC_LICENSE_KEY')
+            if licensekey is None:
+                licensekey = self.config.application.license_key
         return licensekey
 
     def get_instance_name(self, plugin_name, instance):


### PR DESCRIPTION
`NEW_RELIC_LICENSE_KEY` is supported by all APMs making it more likely to be used than `NEWRELIC_LICENSE_KEY` - See any of the APM docs, https://www.npmjs.com/package/newrelic has a mention of it for example.